### PR TITLE
Switched to netstandard2.0

### DIFF
--- a/CustomSpawns/CustomSpawns.csproj
+++ b/CustomSpawns/CustomSpawns.csproj
@@ -1,47 +1,38 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net472</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <Platforms>x64</Platforms>
         <LangVersion>9.0</LangVersion>
         <Nullable>enable</Nullable>
-        <Configurations>Debug;Release</Configurations>
     </PropertyGroup>
 
     <PropertyGroup>
-        <ModuleName>CustomSpawns</ModuleName>
-        <DisplayName>Custom Spawns API</DisplayName>
-        <AssemblyName>$(ModuleName)</AssemblyName>
+        <BuildForWindows>true</BuildForWindows>
+        <BuildForWindowsStore>true</BuildForWindowsStore>
+        <ModuleId>CustomSpawns</ModuleId>
+        <ModuleName>Custom Spawns API</ModuleName>
+        <ModuleUrl>https://www.nexusmods.com/mountandblade2bannerlord/mods/411</ModuleUrl>
+        <AssemblyName>$(ModuleId)</AssemblyName>
+        <OverrideAssemblyName>false</OverrideAssemblyName>
         <Version>1.9.4</Version>
     </PropertyGroup>
 
     <!-- Versions of Major Dependencies (For Package References & SubModule.xml Substitution) -->
     <PropertyGroup>
-        <BuildResourcesVersion>1.0.0.33</BuildResourcesVersion>
+        <BuildResourcesVersion>1.1.0.100</BuildResourcesVersion>
         <HarmonyVersion>2.2.2</HarmonyVersion>
     </PropertyGroup>
 
     <!-- NuGet Packages -->
     <ItemGroup>
-        <PackageReference Include="Bannerlord.BuildResources" Version="$(BuildResourcesVersion)">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Lib.Harmony" Version="$(HarmonyVersion)" PrivateAssets="All" />
-
+        <PackageReference Include="Bannerlord.BuildResources" Version="$(BuildResourcesVersion)" PrivateAssets="All" />
+        <PackageReference Include="Bannerlord.Lib.Harmony" Version="$(HarmonyVersion)" PrivateAssets="All" />
         <PackageReference Include="Bannerlord.ReferenceAssemblies.Core" Version="$(GameVersion).*" PrivateAssets="All" />
         <PackageReference Include="Bannerlord.ReferenceAssemblies.Native" Version="$(GameVersion).*" PrivateAssets="All" />
         <PackageReference Include="Bannerlord.ReferenceAssemblies.StoryMode" Version="$(GameVersion).*" PrivateAssets="All" />
         <PackageReference Include="Bannerlord.ReferenceAssemblies.Sandbox" Version="$(GameVersion).*" PrivateAssets="All" />
-        <Reference Include="System.Windows.Forms" />
-    </ItemGroup>
-
-    <!-- Extra Substitution Variables to Use in SubModule.xml -->
-    <ItemGroup>
-        <SubModuleOverrides Include="DisplayName">
-            <Regex>\$displayname\$</Regex>
-            <Replacement>$(DisplayName)</Replacement>
-        </SubModuleOverrides>
+        <PackageReference Include="BUTR.MessageBoxPInvoke" Version="1.0.0.1" />
     </ItemGroup>
 
 </Project>

--- a/CustomSpawns/Data/Dao/SpawnDao.cs
+++ b/CustomSpawns/Data/Dao/SpawnDao.cs
@@ -78,10 +78,10 @@ namespace CustomSpawns.Data.Dao
             IList<SpawnDto> spawns = Spawns();
             if (spawns.All(spawn => spawn.SpawnAlongWith.IsEmpty()))
             {
-                return new HashSet<string>(0);
+                return new HashSet<string>();
             }
 
-            return spawns
+            return new HashSet<string>(spawns
                 .Select(spawn => spawn.SpawnAlongWith.AsEnumerable())
                 .Aggregate((allSupporters, supportingPartyTemplates) =>
                 {
@@ -89,15 +89,13 @@ namespace CustomSpawns.Data.Dao
                     newSupporters.AddRange(supportingPartyTemplates);
                     return newSupporters;
                 })
-                .Select(partyTemplate => partyTemplate.templateObject.StringId)
-                .ToHashSet();
+                .Select(partyTemplate => partyTemplate.templateObject.StringId));
         }
 
         public ISet<string> FindAllPartyTemplateId()
         {
-            return Spawns()
-                .Select(spawn => spawn.PartyTemplate.StringId)
-                .ToHashSet();
+            return new HashSet<string>(Spawns()
+                .Select(spawn => spawn.PartyTemplate.StringId));
         }
     }
 }

--- a/CustomSpawns/Data/Reader/Impl/DiplomacyDataReader.cs
+++ b/CustomSpawns/Data/Reader/Impl/DiplomacyDataReader.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;
-using CustomSpawns.Exception;
 using CustomSpawns.ModIntegration;
 using CustomSpawns.Utils;
 using MonoMod.Utils;
@@ -35,7 +34,10 @@ namespace CustomSpawns.Data.Reader.Impl
                 {
                     try
                     {
-                        diplomacyData.AddRange(ConstructListFromXML(path));       
+                        foreach (var kv in ConstructListFromXML(path))
+                        {
+                            diplomacyData.Add(kv.Key, kv.Value);
+                        }
                     }
                     catch (ArgumentException e)
                     {

--- a/CustomSpawns/Utils/MessageBoxService.cs
+++ b/CustomSpawns/Utils/MessageBoxService.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Windows.Forms;
+using BUTR.MessageBoxPInvoke.Helpers;
 using TaleWorlds.Library;
 
 namespace CustomSpawns.Utils
@@ -41,7 +41,7 @@ namespace CustomSpawns.Utils
             }
             else
             {
-                MessageBox.Show(errorMessage);
+                MessageBoxDialog.Show(errorMessage);
             }
         }
 

--- a/CustomSpawns/_Module/SubModule.xml
+++ b/CustomSpawns/_Module/SubModule.xml
@@ -1,32 +1,34 @@
- <Module>
-	<Name value="$displayname$"/>
-	<Id value="$modulename$"/>
-	<Version value="v$version$"/>
-	<SingleplayerModule value="true"/>
-	<MultiplayerModule value="false"/>
-	<ModuleType value="Community"/>
-	<ModuleCategory value="Singleplayer" />
-	 <DependedModules>
-		 <DependedModule Id="Native" DependentVersion="v$gameversion$" Optional="false"/>
-		 <DependedModule Id="SandBoxCore" DependentVersion="v$gameversion$" Optional="false"/>
-		 <DependedModule Id="Sandbox" DependentVersion="v$gameversion$" Optional="false"/>
-	 </DependedModules>
-	 <DependedModuleMetadatas>
-		 <DependedModuleMetadata id="Native" order="LoadBeforeThis" version="v$gameversion$.*"/>
-		 <DependedModuleMetadata id="SandBoxCore" order="LoadBeforeThis" version="v$gameversion$.*"/>
-		 <DependedModuleMetadata id="Sandbox" order="LoadBeforeThis" version="v$gameversion$.*"/>
-	 </DependedModuleMetadatas>
-	<SubModules>
-		<SubModule>
-			<Name value="CustomSpawns"/>
-			<DLLName value="CustomSpawns.dll"/>
-			<SubModuleClassType value="CustomSpawns.Main"/>
-			<Tags>
-				<Tag key="DedicatedServerType" value="none"/>
-				<Tag key="IsNoRenderModeElement" value="false"/>
-			</Tags>
-		</SubModule>
-	</SubModules>
-     <Xmls>
-     </Xmls>
- </Module>
+<?xml version="1.0" encoding="UTF-8"?>
+<Module xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/BUTR/Bannerlord.XmlSchemas/master/SubModule.xsd" >
+  <Id value="$moduleid$" />
+  <Name value="$modulename$"/>
+  <Version value="v$version$" />
+  <DefaultModule value="false" />
+  <ModuleCategory value="Singleplayer" />
+  <ModuleType value="Community" />
+  <Url value="$moduleurl$" />
+  <DependedModules>
+    <DependedModule Id="Native" DependentVersion="$gameversion$" Optional="false"/>
+    <DependedModule Id="SandBoxCore" DependentVersion="$gameversion$" Optional="false"/>
+    <DependedModule Id="Sandbox" DependentVersion="$gameversion$" Optional="false"/>
+  </DependedModules>
+  <DependedModuleMetadatas>
+    <DependedModuleMetadata id="Native" order="LoadBeforeThis" version="$gameversion$.*"/>
+    <DependedModuleMetadata id="SandBoxCore" order="LoadBeforeThis" version="$gameversion$.*"/>
+    <DependedModuleMetadata id="Sandbox" order="LoadBeforeThis" version="$gameversion$.*"/>
+  </DependedModuleMetadatas>
+  <SubModules>
+    <SubModule>
+      <Name value="CustomSpawns"/>
+      <DLLName value="CustomSpawns.dll"/>
+      <SubModuleClassType value="CustomSpawns.Main"/>
+      <Tags>
+        <Tag key="DedicatedServerType" value="none"/>
+        <Tag key="IsNoRenderModeElement" value="false"/>
+      </Tags>
+    </SubModule>
+  </SubModules>
+  <Xmls>
+  </Xmls>
+</Module>


### PR DESCRIPTION
The main motivation is the switch to netstandard2.0 to support both .NET Framework 4.7.2 of Steam/GOG/Epic and .NET Core 3.1 of Xbox Game Pass PC
There are a few missing API's for Dictionary and HashSet, plus I added our PInvoke wrapper for MessageBox
I also update BuildResources and SubModule.xml

Harmony was switched from Lib.Harmony to Bannerlord.Lib.Harmony.
This change is most likely temporarily and the next version of Lib.Harmony will have netstandard2.0 support, after which we can return to Lib.Harmony, but there are a few potential issues