### PR TITLE
Adding null checks to dialogue conditions

### DIFF
--- a/CustomSpawns/Dialogues/DialogueConditionInterpretor.cs
+++ b/CustomSpawns/Dialogues/DialogueConditionInterpretor.cs
@@ -314,7 +314,9 @@ namespace CustomSpawns.Dialogues
         [DialogueConditionImplementor("IsHostile")]
         private static bool IsHostile(DialogueParams param)
         {
-            if (param.AdversaryParty == null)
+            // added a null check for the MapFaction to address a crash from npcs that are created by SaS for random events
+            // can also rarely occur with the weaponsmith, nobles
+            if (param.AdversaryParty == null || param.AdversaryParty.MapFaction == null)
                 return false;
 
             return param.AdversaryParty.MapFaction.IsAtWarWith(param.PlayerParty.MapFaction);

--- a/CustomSpawns/Dialogues/DialogueConditionInterpretor.cs
+++ b/CustomSpawns/Dialogues/DialogueConditionInterpretor.cs
@@ -283,7 +283,7 @@ namespace CustomSpawns.Dialogues
         [DialogueConditionImplementor("PartyIsInFaction")]
         private static bool PartyIsInFaction(DialogueParams param, string factionID)
         {
-            if (param.AdversaryParty == null)
+            if (param.AdversaryParty == null || param.AdversaryParty.MapFaction == null)
                 return false;
 
             return param.AdversaryParty.MapFaction.StringId.ToString() == factionID;
@@ -304,7 +304,7 @@ namespace CustomSpawns.Dialogues
         [DialogueConditionImplementor("IsFriendly")]
         private static bool IsFriendly(DialogueParams param)
         {
-            if (param.AdversaryParty == null)
+            if (param.AdversaryParty == null || param.AdversaryParty.MapFaction == null)
                 return false;
 
             return !param.AdversaryParty.MapFaction.IsAtWarWith(param.PlayerParty.MapFaction);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 Version: 2.0.1
 Game Versions: v1.2.x
-* Fix: Added null check for npcs without a map faction to IsHostile
+* Fix: Added null checks for references to MapFaction in Dialogue Interpretor. Compatability with SaS
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.0
 Game Versions: v1.2.0,v1.2.1,v1.2.2,v1.2.3,v1.2.4,v1.2.5,v1.2.6,v1.2.7,v1.2.8

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 Version: 2.0.1
 Game Versions: v1.2.x
-* Fix: Added null checks for references to MapFaction in Dialogue Interpretor. Compatability with SaS
+* Fix : Factionless npcs dialogues should no longer cause crashes. Improves compatibility with non-Custom Spawns mods.
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.0
 Game Versions: v1.2.0,v1.2.1,v1.2.2,v1.2.3,v1.2.4,v1.2.5,v1.2.6,v1.2.7,v1.2.8

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version: 2.0.1
+Game Versions: v1.2.x
+* Fix: Added null check for npcs without a map faction to IsHostile
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.0
 Game Versions: v1.2.0,v1.2.1,v1.2.2,v1.2.3,v1.2.4,v1.2.5,v1.2.6,v1.2.7,v1.2.8


### PR DESCRIPTION
CS + serve as soldier was causing crashes at the end of SaS events when opening dialogues.
Npc notables that don't have a map faction were sending nulls into the dialogue conditions.

There were also rare cases where npcs with factions like a kingdom leader were getting a null from .MapFaction, but those are covered by the same fix anyways.